### PR TITLE
Added support for PersistentStorageType 

### DIFF
--- a/templates/confluent-kafka-master.template
+++ b/templates/confluent-kafka-master.template
@@ -46,6 +46,7 @@
                         "NumBrokers",
                         "BrokerNodeInstanceType",
                         "BrokerNodeStorage",
+                        "BrokerNodeStorageType",
                         "BrokerNodeSpotPrice"
                     ]
                 },
@@ -96,6 +97,9 @@
                 },
                 "BrokerNodeStorage": {
                     "default": "Persistent Storage"
+                },
+                "BrokerNodeStorageType": {
+                    "default": "EBS Volume Type"
                 },
                 "ClusterName": {
                     "default": "Cluster Name"
@@ -210,12 +214,23 @@
             "Type": "String"
         },
         "BrokerNodeStorage": {
-            "ConstraintDescription": "No more than 1024 GiB per device (4 TiB per node).",
-            "Default": "0",
+            "ConstraintDescription": "No more than 4096 GiB per device (4 TiB per node).",
+            "Default": "512",
             "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
-            "MaxValue": "1024",
+            "MaxValue": "4096",
             "MinValue": "0",
             "Type": "Number"
+        },
+        "BrokerNodeStorageType": {
+            "AllowedValues": [
+                "",
+                "gp2",
+                "sc1",
+                "st1"
+            ],
+            "Default": "st1",
+            "Description": "EBS volume type (blank indicates default type for ami/region).  sc1 and st1 volumes must be at least 500 GB in size.",
+            "Type": "String"
         },
         "ClusterName": {
             "AllowedPattern": "([A-Za-z]{1}[0-9A-Za-z_-]*)",
@@ -366,10 +381,10 @@
             "Type": "String"
         },
         "WorkerNodeStorage": {
-            "ConstraintDescription": "No more than 1024 GiB per device (4 TiB per node).",
+            "ConstraintDescription": "No more than 4096 GiB per device (4 TiB per node).",
             "Default": "0",
             "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
-            "MaxValue": "1024",
+            "MaxValue": "4096",
             "MinValue": "0",
             "Type": "Number"
         },
@@ -395,10 +410,10 @@
             "Type": "String"
         },
         "ZookeeperNodeStorage": {
-            "ConstraintDescription": "No more than 1024 GiB per device (4 TiB per node).",
+            "ConstraintDescription": "No more than 4096 GiB per device (4 TiB per node).",
             "Default": "0",
             "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
-            "MaxValue": "1024",
+            "MaxValue": "4096",
             "MinValue": "0",
             "Type": "Number"
         }
@@ -556,6 +571,9 @@
                     },
                     "BrokerNodeStorage": {
                         "Ref": "BrokerNodeStorage"
+                    },
+                    "BrokerNodeStorageType": {
+                        "Ref": "BrokerNodeStorageType"
                     },
                     "ClusterName": {
                         "Ref": "ClusterName"

--- a/templates/confluent-kafka.template
+++ b/templates/confluent-kafka.template
@@ -44,6 +44,7 @@
                         "NumBrokers",
                         "BrokerNodeInstanceType",
                         "BrokerNodeStorage",
+                        "BrokerNodeStorageType",
                         "BrokerNodeSpotPrice"
                     ]
                 },
@@ -91,6 +92,9 @@
                 },
                 "BrokerNodeStorage": {
                     "default": "Persistent Storage"
+                },
+                "BrokerNodeStorageType": {
+                    "default": "EBS Volume Type"
                 },
                 "ClusterName": {
                     "default": "Cluster Name"
@@ -195,12 +199,23 @@
             "Type": "String"
         },
         "BrokerNodeStorage": {
-            "ConstraintDescription": "No more than 1024 GiB per device (4 TiB per node).",
-            "Default": "0",
+            "ConstraintDescription": "No more than 4096 GiB per device (16 TiB per node).",
+            "Default": "512",
             "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
-            "MaxValue": "1024",
+            "MaxValue": "4096",
             "MinValue": "0",
             "Type": "Number"
+        },
+        "BrokerNodeStorageType": {
+            "AllowedValues": [
+                "",
+                "gp2",
+                "sc1",
+                "st1"
+            ],
+            "Default": "st1",
+            "Description": "EBS volume type (blank indicates default type for ami/region).  sc1 and st1 volumes must be at least 500 GB in size.",
+            "Type": "String"
         },
         "ClusterName": {
             "AllowedPattern": "([A-Za-z]{1}[0-9A-Za-z_-]*)",
@@ -338,10 +353,10 @@
             "Type": "String"
         },
         "WorkerNodeStorage": {
-            "ConstraintDescription": "No more than 1024 GiB per device (4 TiB per node).",
+            "ConstraintDescription": "No more than 4096 GiB per device (16 TiB per node).",
             "Default": "0",
             "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
-            "MaxValue": "1024",
+            "MaxValue": "4096",
             "MinValue": "0",
             "Type": "Number"
         },
@@ -367,10 +382,10 @@
             "Type": "String"
         },
         "ZookeeperNodeStorage": {
-            "ConstraintDescription": "No more than 1024 GiB per device (4 TiB per node).",
+            "ConstraintDescription": "No more than 4096 GiB per device (16 TiB per node).",
             "Default": "0",
             "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
-            "MaxValue": "1024",
+            "MaxValue": "4096",
             "MinValue": "0",
             "Type": "Number"
         }
@@ -615,6 +630,9 @@
                     },
                     "PersistentStorage": {
                         "Ref": "BrokerNodeStorage"
+                    },
+                    "PersistentStorageType": {
+                        "Ref": "BrokerNodeStorageType"
                     },
                     "QSS3BucketName": {
                         "Ref": "QSS3BucketName"

--- a/templates/nodegroup.template
+++ b/templates/nodegroup.template
@@ -81,9 +81,12 @@
         },
         "NodeInstanceType": {
             "AllowedValues": [
+                "t2.medium",
+                "t2.large",
                 "m3.medium",
                 "m3.large",
                 "m3.xlarge",
+                "m3.2xlarge",
                 "m4.large",
                 "m4.xlarge",
                 "m4.2xlarge",
@@ -126,12 +129,23 @@
             "Type": "String"
         },
         "PersistentStorage": {
-            "ConstraintDescription": "No more than 1024 GB per device (4 TB per node).",
+            "ConstraintDescription": "No more than 4096 GB per device (16 TB per node).",
             "Default": "0",
             "Description": "Allocated EBS storage for each block device (in GB; 4 devs per node); 0 indicates ephemeral storage only",
-            "MaxValue": "1024",
+            "MaxValue": "4096",
             "MinValue": "0",
             "Type": "Number"
+        },
+        "PersistentStorageType": {
+            "AllowedValues": [
+                "",
+                "gp2",
+                "sc1",
+                "st1"
+            ],
+            "Default": "",
+            "Description": "EBS volume type (blank indicates default type for ami/region).  sc1 and st1 volumes must be at least 500 GB in size.",
+            "Type": "String"
         },
         "QSS3BucketName": {
             "AllowedPattern": "^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$",
@@ -326,6 +340,14 @@
                     "Ref": "NodeSpotPrice"
                 },
                 "0.00"
+            ]
+        },
+        "UseDefaultVT": {
+            "Fn::Equals": [
+                {
+                    "Ref": "PersistentStorageType"
+                },
+                ""
             ]
         }
     },
@@ -784,6 +806,13 @@
                                     "VolumeSize": {
                                         "Ref": "PersistentStorage"
                                     },
+                                    "VolumeType": {
+                                        "Fn::If": [ 
+                                            "UseDefaultVT",
+                                            { "Ref": "AWS::NoValue" }, 
+                                            { "Ref": "PersistentStorageType" }
+                                        ]
+                                    },
                                     "DeleteOnTermination": "True"
                                 }
                             },
@@ -792,6 +821,13 @@
                                 "Ebs": {
                                     "VolumeSize": {
                                         "Ref": "PersistentStorage"
+                                    },
+                                    "VolumeType": {
+                                        "Fn::If": [ 
+                                            "UseDefaultVT",
+                                            { "Ref": "AWS::NoValue" }, 
+                                            { "Ref": "PersistentStorageType" }
+                                        ]
                                     },
                                     "DeleteOnTermination": "True"
                                 }
@@ -802,6 +838,13 @@
                                     "VolumeSize": {
                                         "Ref": "PersistentStorage"
                                     },
+                                    "VolumeType": {
+                                        "Fn::If": [ 
+                                            "UseDefaultVT",
+                                            { "Ref": "AWS::NoValue" }, 
+                                            { "Ref": "PersistentStorageType" }
+                                        ]
+                                    },
                                     "DeleteOnTermination": "True"
                                 }
                             },
@@ -810,6 +853,13 @@
                                 "Ebs": {
                                     "VolumeSize": {
                                         "Ref": "PersistentStorage"
+                                    },
+                                    "VolumeType": {
+                                        "Fn::If": [ 
+                                            "UseDefaultVT",
+                                            { "Ref": "AWS::NoValue" }, 
+                                            { "Ref": "PersistentStorageType" }
+                                        ]
                                     },
                                     "DeleteOnTermination": "True"
                                 }


### PR DESCRIPTION
Minor changes to nodegroup.teemplate
(allowing override of default EBS volume type), and
enabled it for the Broker configuration in the main
confluent-kafka templates.

#16 