### PR TITLE
Add a parameter for AssociatePublicIpAddress

### DIFF
--- a/ci/enterprise-3.1.2-brokersworkerszookeepers-spot-ebs-amzn.json
+++ b/ci/enterprise-3.1.2-brokersworkerszookeepers-spot-ebs-amzn.json
@@ -1,5 +1,9 @@
 [
     {
+        "ParameterKey": "AssignPublicIP",
+        "ParameterValue": "true"
+    },
+    {
         "ParameterKey": "AvailabilityZones",
         "ParameterValue": "$[alfred_getaz_2]"
     },
@@ -54,6 +58,14 @@
     {
         "ParameterKey": "NumZookeepers",
         "ParameterValue": "3"
+    },
+    {
+        "ParameterKey": "PrivateSubnet1CIDR",
+        "ParameterValue": "10.0.0.0/19"
+    },
+    {
+        "ParameterKey": "PrivateSubnet2CIDR",
+        "ParameterValue": "10.0.32.0/19"
     },
     {
         "ParameterKey": "PublicSubnet1CIDR",

--- a/ci/enterprise-default-brokersonly-ondemand-ephemeral-centos.json
+++ b/ci/enterprise-default-brokersonly-ondemand-ephemeral-centos.json
@@ -1,5 +1,9 @@
 [
     {
+        "ParameterKey": "AssignPublicIP",
+        "ParameterValue": "true"
+    },
+    {
         "ParameterKey": "AvailabilityZones",
         "ParameterValue": "$[alfred_getaz_2]"
     },
@@ -50,6 +54,14 @@
     {
         "ParameterKey": "NumZookeepers",
         "ParameterValue": "0"
+    },
+    {
+        "ParameterKey": "PrivateSubnet1CIDR",
+        "ParameterValue": "10.0.0.0/19"
+    },
+    {
+        "ParameterKey": "PrivateSubnet2CIDR",
+        "ParameterValue": "10.0.32.0/19"
     },
     {
         "ParameterKey": "PublicSubnet1CIDR",

--- a/ci/enterprise-default-brokersworkerszookeepers-ondemand-ephemeral-ubuntu.json
+++ b/ci/enterprise-default-brokersworkerszookeepers-ondemand-ephemeral-ubuntu.json
@@ -1,5 +1,9 @@
 [
     {
+        "ParameterKey": "AssignPublicIP",
+        "ParameterValue": "true"
+    },
+    {
         "ParameterKey": "AvailabilityZones",
         "ParameterValue": "$[alfred_getaz_2]"
     },
@@ -50,6 +54,14 @@
     {
         "ParameterKey": "NumZookeepers",
         "ParameterValue": "3"
+    },
+    {
+        "ParameterKey": "PrivateSubnet1CIDR",
+        "ParameterValue": "10.0.0.0/19"
+    },
+    {
+        "ParameterKey": "PrivateSubnet2CIDR",
+        "ParameterValue": "10.0.32.0/19"
     },
     {
         "ParameterKey": "PublicSubnet1CIDR",

--- a/ci/enterprise-default-brokerszookeepers-ondemand-ephemeral-centos.json
+++ b/ci/enterprise-default-brokerszookeepers-ondemand-ephemeral-centos.json
@@ -1,5 +1,9 @@
 [
     {
+        "ParameterKey": "AssignPublicIP",
+        "ParameterValue": "true"
+    },
+    {
         "ParameterKey": "AvailabilityZones",
         "ParameterValue": "$[alfred_getaz_2]"
     },
@@ -50,6 +54,14 @@
     {
         "ParameterKey": "NumZookeepers",
         "ParameterValue": "3"
+    },
+    {
+        "ParameterKey": "PrivateSubnet1CIDR",
+        "ParameterValue": "10.0.0.0/19"
+    },
+    {
+        "ParameterKey": "PrivateSubnet2CIDR",
+        "ParameterValue": "10.0.32.0/19"
     },
     {
         "ParameterKey": "PublicSubnet1CIDR",

--- a/ci/opensource-default-brokersworkerszookeepers-ondemand-ephemeral-ubuntu.json
+++ b/ci/opensource-default-brokersworkerszookeepers-ondemand-ephemeral-ubuntu.json
@@ -1,5 +1,9 @@
 [
     {
+        "ParameterKey": "AssignPublicIP",
+        "ParameterValue": "true"
+    },
+    {
         "ParameterKey": "AvailabilityZones",
         "ParameterValue": "$[alfred_getaz_2]"
     },
@@ -50,6 +54,14 @@
     {
         "ParameterKey": "NumZookeepers",
         "ParameterValue": "3"
+    },
+    {
+        "ParameterKey": "PrivateSubnet1CIDR",
+        "ParameterValue": "10.0.0.0/19"
+    },
+    {
+        "ParameterKey": "PrivateSubnet2CIDR",
+        "ParameterValue": "10.0.32.0/19"
     },
     {
         "ParameterKey": "PublicSubnet1CIDR",

--- a/templates/confluent-kafka-master.template
+++ b/templates/confluent-kafka-master.template
@@ -462,14 +462,6 @@
                 },
                 "false"
             ]
-        },
-        "PublicSubnetCondition": {
-            "Fn::Equals": [
-                {
-                    "Ref": "AssignPublicIP"
-                },
-                "true"
-            ]
         }
     },
     "Mappings": {
@@ -696,34 +688,34 @@
                             [
                                 {
                                     "Fn::If": [
-                                        "PublicSubnetCondition",
+                                        "PrivateSubnetCondition",
+                                        {
+                                            "Fn::GetAtt": [
+                                                "VPCStack",
+                                                "Outputs.PrivateSubnet1AID"
+                                            ]
+                                        },
                                         {
                                             "Fn::GetAtt": [
                                                 "VPCStack",
                                                 "Outputs.PublicSubnet1ID"
                                             ]
                                         },
-                                        {
-                                            "Fn::GetAtt": [
-                                                "VPCStack",
-                                                "Outputs.PrivateSubnet1ID"
-                                            ]
-                                        },
                                     ]
                                 },
                                 {
                                     "Fn::If": [
-                                        "PublicSubnetCondition",
+                                        "PrivateSubnetCondition",
                                         {
                                             "Fn::GetAtt": [
                                                 "VPCStack",
-                                                "Outputs.PublicSubnet2ID"
+                                                "Outputs.PrivateSubnet2AID"
                                             ]
                                         },
                                         {
                                             "Fn::GetAtt": [
                                                 "VPCStack",
-                                                "Outputs.PrivateSubnet2ID"
+                                                "Outputs.PublicSubnet2ID"
                                             ]
                                         },
                                     ]

--- a/templates/confluent-kafka-master.template
+++ b/templates/confluent-kafka-master.template
@@ -455,6 +455,14 @@
         }
     },
     "Conditions": {
+        "PrivateSubnetCondition": {
+            "Fn::Equals": [
+                {
+                    "Ref": "AssignPublicIP"
+                },
+                "false"
+            ]
+        },
         "PublicSubnetCondition": {
             "Fn::Equals": [
                 {
@@ -567,10 +575,26 @@
                     },
                     "NumberOfAZs": "2",
                     "PrivateSubnet1ACIDR": {
-                        "Ref": "PrivateSubnet1CIDR"
+                        "Fn::If": [
+                            "PrivateSubnetCondition",
+                            {
+                                "Ref": "PrivateSubnet1CIDR"
+                            },
+                            {
+                                "Ref" : "AWS::NoValue"
+                            }
+                        ]
                     },
                     "PrivateSubnet2ACIDR": {
-                        "Ref": "PrivateSubnet2CIDR"
+                        "Fn::If": [
+                            "PrivateSubnetCondition",
+                            {
+                                "Ref": "PrivateSubnet2CIDR"
+                            },
+                            {
+                                "Ref" : "AWS::NoValue"
+                            }
+                        ]
                     },
                     "PublicSubnet1CIDR": {
                         "Ref": "PublicSubnet1CIDR"

--- a/templates/confluent-kafka-master.template
+++ b/templates/confluent-kafka-master.template
@@ -671,27 +671,37 @@
                             ",",
                             [
                                 {
-                                    "Fn::GetAtt": [
-                                        "VPCStack",
+                                    "Fn::If": [
+                                        "PublicSubnetCondition",
                                         {
-                                            "Fn::If": [
-                                                "PublicSubnetCondition",
-                                                "Outputs.PublicSubnet1ID",
+                                            "Fn::GetAtt": [
+                                                "VPCStack",
+                                                "Outputs.PublicSubnet1ID"
+                                            ]
+                                        },
+                                        {
+                                            "Fn::GetAtt": [
+                                                "VPCStack",
                                                 "Outputs.PrivateSubnet1ID"
                                             ]
-                                        }
+                                        },
                                     ]
                                 },
                                 {
-                                    "Fn::GetAtt": [
-                                        "VPCStack",
+                                    "Fn::If": [
+                                        "PublicSubnetCondition",
                                         {
-                                            "Fn::If": [
-                                                "PublicSubnetCondition",
-                                                "Outputs.PublicSubnet2ID",
+                                            "Fn::GetAtt": [
+                                                "VPCStack",
+                                                "Outputs.PublicSubnet2ID"
+                                            ]
+                                        },
+                                        {
+                                            "Fn::GetAtt": [
+                                                "VPCStack",
                                                 "Outputs.PrivateSubnet2ID"
                                             ]
-                                        }
+                                        },
                                     ]
                                 }
                             ]

--- a/templates/confluent-kafka-master.template
+++ b/templates/confluent-kafka-master.template
@@ -11,6 +11,8 @@
                     "Parameters": [
                         "AvailabilityZones",
                         "VPCCIDR",
+                        "PrivateSubnet1CIDR",
+                        "PrivateSubnet2CIDR",
                         "PublicSubnet1CIDR",
                         "PublicSubnet2CIDR",
                         "RemoteAccessCIDR",
@@ -131,6 +133,12 @@
                 },
                 "NumZookeepers": {
                     "default": "Zookeeper count"
+                },
+                "PrivateSubnet1CIDR": {
+                    "default": "Private Subnet 1 CIDR"
+                },
+                "PrivateSubnet2CIDR": {
+                    "default": "Private Subnet 2 CIDR"
                 },
                 "PublicSubnet1CIDR": {
                     "default": "Public Subnet 1 CIDR"
@@ -318,6 +326,20 @@
             "Description": "Number of independent Zookeepers (if 0, zookeeper will be deployed on the Kafka brokers)",
             "Type": "String"
         },
+        "PrivateSubnet1CIDR": {
+            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
+            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/16-28",
+            "Default": "10.0.0.0/19",
+            "Description": "CIDR block for private subnet 1 located in Availability Zone 1.",
+            "Type": "String"
+        },
+        "PrivateSubnet2CIDR": {
+            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
+            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/16-28",
+            "Default": "10.0.32.0/19",
+            "Description": "CIDR block for private subnet 2 located in Availability Zone 2.",
+            "Type": "String"
+        },
         "PublicSubnet1CIDR": {
             "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
             "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/16-28",
@@ -432,6 +454,16 @@
             "Type": "Number"
         }
     },
+    "Conditions": {
+        "PublicSubnetCondition": {
+            "Fn::Equals": [
+                {
+                    "Ref": "AssignPublicIP"
+                },
+                "true"
+            ]
+        }
+    },
     "Mappings": {
         "AWSInfoRegionMap": {
             "ap-northeast-1": {
@@ -534,6 +566,12 @@
                         "Ref": "KeyPairName"
                     },
                     "NumberOfAZs": "2",
+                    "PrivateSubnet1ACIDR": {
+                        "Ref": "PrivateSubnet1CIDR"
+                    },
+                    "PrivateSubnet2ACIDR": {
+                        "Ref": "PrivateSubnet2CIDR"
+                    },
                     "PublicSubnet1CIDR": {
                         "Ref": "PublicSubnet1CIDR"
                     },
@@ -635,13 +673,25 @@
                                 {
                                     "Fn::GetAtt": [
                                         "VPCStack",
-                                        "Outputs.PublicSubnet1ID"
+                                        {
+                                            "Fn::If": [
+                                                "PublicSubnetCondition",
+                                                "Outputs.PublicSubnet1ID",
+                                                "Outputs.PrivateSubnet1ID"
+                                            ]
+                                        }
                                     ]
                                 },
                                 {
                                     "Fn::GetAtt": [
                                         "VPCStack",
-                                        "Outputs.PublicSubnet2ID"
+                                        {
+                                            "Fn::If": [
+                                                "PublicSubnetCondition",
+                                                "Outputs.PublicSubnet2ID",
+                                                "Outputs.PrivateSubnet2ID"
+                                            ]
+                                        }
                                     ]
                                 }
                             ]

--- a/templates/confluent-kafka-master.template
+++ b/templates/confluent-kafka-master.template
@@ -35,7 +35,8 @@
                     "Parameters": [
                         "KeyPairName",
                         "LinuxOSAMI",
-                        "BootDiskSize"
+                        "BootDiskSize",
+                        "AssignPublicIP"
                     ]
                 },
                 {
@@ -83,6 +84,9 @@
                 }
             ],
             "ParameterLabels": {
+                "AssignPublicIP": {
+                    "default": "Allocate a public IP for each instance"
+                },
                 "AvailabilityZones": {
                     "default": "Availability Zones"
                 },
@@ -171,6 +175,16 @@
         }
     },
     "Parameters": {
+        "AssignPublicIP": {
+            "AllowedValues": [
+              "true",
+              "false"
+            ],
+            "ConstraintDescription": "Either true or false",
+            "Default": "true",
+            "Description": "Allociate a public IP address to each instance",
+            "Type": "String"
+        },
         "AvailabilityZones": {
             "Description": "List of Availability Zones to use for the subnets in the VPC. Note: The logical order is preserved and only 2 AZs are used for this deployment.",
             "Type": "List<AWS::EC2::AvailabilityZone::Name>"
@@ -560,6 +574,9 @@
                     ]
                 },
                 "Parameters": {
+                    "AssignPublicIP": {
+                        "Ref": "AssignPublicIP"
+                    },
                     "BootDiskSize": {
                         "Ref": "BootDiskSize"
                     },

--- a/templates/confluent-kafka-master.template
+++ b/templates/confluent-kafka-master.template
@@ -561,7 +561,13 @@
                             }
                         ]
                     },
-                    "CreatePrivateSubnets": "false",
+                    "CreatePrivateSubnets": {
+                        "Fn::If": [
+                            "PrivateSubnetCondition",
+                            "true",
+                            "false"
+                        ]
+                    },
                     "KeyPairName": {
                         "Ref": "KeyPairName"
                     },

--- a/templates/confluent-kafka.template
+++ b/templates/confluent-kafka.template
@@ -33,7 +33,8 @@
                     "Parameters": [
                         "KeyPairName",
                         "LinuxOSAMI",
-                        "BootDiskSize"
+                        "BootDiskSize",
+                        "AssignPublicIP"
                     ]
                 },
                 {
@@ -81,6 +82,9 @@
                 }
             ],
             "ParameterLabels": {
+                "AssignPublicIP": {
+                    "default": "Allocate a public IP for each instance"
+                },
                 "BootDiskSize": {
                     "default": "Boot Disk Capacity (GiB)"
                 },
@@ -160,6 +164,16 @@
         }
     },
     "Parameters": {
+        "AssignPublicIP": {
+            "AllowedValues": [
+              "true",
+              "false"
+            ],
+            "ConstraintDescription": "Either true or false",
+            "Default": "true",
+            "Description": "Allociate a public IP address to each instance",
+            "Type": "String"
+        },
         "BootDiskSize": {
             "ConstraintDescription": "Deployment supports 8 to 128 GB for boot volumes",
             "Default": "24",
@@ -585,6 +599,9 @@
                     ]
                 },
                 "Parameters": {
+                    "AssignPublicIP": {
+                        "Ref": "AssignPublicIP"
+                    },
                     "BootDiskSize": {
                         "Ref": "BootDiskSize"
                     },
@@ -679,6 +696,9 @@
                     ]
                 },
                 "Parameters": {
+                    "AssignPublicIP": {
+                        "Ref": "AssignPublicIP"
+                    },
                     "BootDiskSize": {
                         "Ref": "BootDiskSize"
                     },
@@ -767,6 +787,9 @@
                     ]
                 },
                 "Parameters": {
+                    "AssignPublicIP": {
+                        "Ref": "AssignPublicIP"
+                    },
                     "BootDiskSize": {
                         "Ref": "BootDiskSize"
                     },

--- a/templates/nodegroup.template
+++ b/templates/nodegroup.template
@@ -2,6 +2,16 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "CloudFormation sub-template for Auto-scaling group deployment",
     "Parameters": {
+        "AssignPublicIP": {
+            "AllowedValues": [
+              "true",
+              "false"
+            ],
+            "ConstraintDescription": "Either true or false",
+            "Default": "true",
+            "Description": "Allociate a public IP address to each instance",
+            "Type": "String"
+        },
         "BootDiskSize": {
             "ConstraintDescription": "Deployment supports 8 to 128 GB for boot volumes",
             "Default": "24",
@@ -920,7 +930,9 @@
                 "KeyName": {
                     "Ref": "KeyPairName"
                 },
-                "AssociatePublicIpAddress": "true",
+                "AssociatePublicIpAddress": {
+                    "Ref": "AssignPublicIP"
+                },
                 "IamInstanceProfile": {
                     "Ref": "InstanceProfile"
                 },


### PR DESCRIPTION
Adds a parameter `AssignPublicIP` to pass to `AssociatePublicIpAddress` in the nodegroup template. Should resolve #29 