### PR TITLE
Support for Confluent 3.3,0 release (against develop this time)

### DIFF
--- a/templates/confluent-kafka-master.template
+++ b/templates/confluent-kafka-master.template
@@ -272,12 +272,12 @@
         },
         "ConfluentVersion": {
             "AllowedValues": [
+                "3.3.0",
                 "3.2.2",
-                "3.2.1",
                 "3.1.2"
             ],
             "ConstraintDescription": "Supported versions of Confluent Platform within AWS Marketplace",
-            "Default": "3.2.2",
+            "Default": "3.3.0",
             "Description": "Confluent Software Version",
             "Type": "String"
         },

--- a/templates/confluent-kafka.template
+++ b/templates/confluent-kafka.template
@@ -249,12 +249,12 @@
         },
         "ConfluentVersion": {
             "AllowedValues": [
+                "3.3.0",
                 "3.2.2",
-                "3.2.1",
                 "3.1.2"
             ],
             "ConstraintDescription": "Supported versions of Confluent Platform within AWS Marketplace",
-            "Default": "3.2.2",
+            "Default": "3.3.0",
             "Description": "Confluent Software Version",
             "Type": "String"
         },

--- a/templates/nodegroup.template
+++ b/templates/nodegroup.template
@@ -50,13 +50,8 @@
             "Type": "String"
         },
         "ConfluentVersion": {
-            "AllowedValues": [
-                "3.2.2",
-                "3.2.1",
-                "3.1.2"
-            ],
             "ConstraintDescription": "Supported versions of Confluent Platform within AWS Marketplace",
-            "Default": "3.2.2",
+            "Default": "3.3.0",
             "Description": "Confluent Software Version",
             "Type": "String"
         },
@@ -884,3 +879,4 @@
         }
     }
 }
+


### PR DESCRIPTION
Quick changes to allowed values on main templates.
Sub-template (nodegroup.template) modified to simplify maintenance; no need for "AllowedValues" test in that template since it is NEVER invoked stand-alone.
