### PR TITLE
FIX: Centos Image Issues. Private IP not detected for output.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,85 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Windows template
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+### Linux template
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS template
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### JetBrains template
+.idea/
+*.iml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml

--- a/scripts/compute-heap-opts
+++ b/scripts/compute-heap-opts
@@ -35,7 +35,7 @@
 #		CONNECT_HEAP_OPTS
 #		CC_HEAP_OPTS
 
-THIS_HOST=`hostname`
+THIS_HOST=`hostname -s`
 
 # set -x
 

--- a/scripts/cp-deploy.sh
+++ b/scripts/cp-deploy.sh
@@ -767,7 +767,7 @@ start_core_services() {
 	if [ $? -eq 0 ] ; then
 		wait_for_zk_quorum
 		if [ $? -ne 0 ] ; then
-        	echo "  WARNING: Zookeeper Quorum not formed; broker start may fail" | tee -a $LOG
+			echo "  WARNING: Zookeeper Quorum not formed; broker start may fail"
 		fi
 
 		if [ -x $CP_HOME/initscripts/cp-kafka-service ] ; then
@@ -1082,6 +1082,12 @@ main()
 	    echo "Insufficient specification for Confluent Platform cluster ... terminating script" >> $LOG
 		exit 1
 	fi
+
+		# Make sure THIS_HOST is set.
+	while [ -z "$THIS_HOST" ] ; do
+		sleep 3
+		THIS_HOST=$(hostname -s)
+	done
 
 	update_kadmin_user
 

--- a/scripts/post-cp-info.sh
+++ b/scripts/post-cp-info.sh
@@ -50,11 +50,11 @@ fi
 # Grab our broker index from /tmp/brokers
 #	REMEMBER: ami-launch-index will ALWAYS be 0 for spot instances
 #
-THIS_HOST=`/bin/hostname`
+THIS_HOST=`/bin/hostname -s`
 murl_top=http://instance-data/latest/meta-data
 broker_index=$(curl -f -s $murl_top/ami-launch-index)
 if [ -r /tmp/brokers ] ; then
-	hindex=$(grep -n `hostname` /tmp/brokers | cut -d: -f1)
+	hindex=$(grep -n `hostname -s` /tmp/brokers | cut -d: -f1)
 
 	if [ -z "$hindex" ] ; then
 		echo "post-cp-info: $THIS_HOST is not a broker; nothing to do" | tee -a $LOG
@@ -163,7 +163,9 @@ CC_HOST_PUB=$(aws ec2 describe-instances --output text --region $THIS_REGION \
   --query 'Reservations[].Instances[].[PublicIpAddress,PublicDnsName,PrivateDnsName,Tags[?Key == `Name`] | [0].Value ]' | \
   grep -w "$CC_HOST" | cut -f 1)
 
-[ -n "$CC_HOST_PUB" ] && [ "$CC_HOST_PUB" != "none" ] && CC_HOST=$CC_HOST_PUB
+shopt -s nocasematch
+[ -n "$CC_HOST_PUB" ] && [[ "$CC_HOST_PUB" != "none" ]] && CC_HOST=$CC_HOST_PUB
+shopt -u nocasematch
 
 echo "Posting the following: " >> $LOG
 	

--- a/scripts/prep-cp-instance.sh
+++ b/scripts/prep-cp-instance.sh
@@ -46,21 +46,21 @@ KADMIN_PASSWD=${KADMIN_PASSWD:-C0nfluent}
 #
 verify_instance_hostname() {
 	SYSCONFIG_NETWORK=/etc/sysconfig/network
-	CUR_HOSTNAME=`hostname`
+	CUR_FQDN=`hostname -f`
 
 	if [ -f $SYSCONFIG_NETWORK ] ; then
-		eval "CFG_`grep ^HOSTNAME= $SYSCONFIG_NETWORK`"
+		CFG_FQDN=`grep ^HOSTNAME= $SYSCONFIG_NETWORK | cut -d "=" -f2`
 
-		if [ "$CFG_HOSTNAME" != "$CUR_HOSTNAME" ] ; then
-			sed -i "s/^HOSTNAME=.*$/HOSTNAME=$CUR_HOSTNAME/" $SYSCONFIG_NETWORK
+		if [ "$CFG_FQDN" != "$CUR_FQDN" ] ; then
+			sed -i "s/^HOSTNAME=.*$/HOSTNAME=$CUR_FQDN/" $SYSCONFIG_NETWORK
 		fi
 	fi
 
 		# Some CentOS images have hard-coded hostnames left in /etc/hostname
 		# Just remove it if it doesn't match (module network domain)
 	if [ -f /etc/hostname ] ; then
-		CFG_HOSTNAME=`cat /etc/hostname`
-		if [ "$CFG_HOSTNAME" != "$CUR_HOSTNAME"  -a  "${CFG_HOSTNAME%%.*}" != "${CUR_HOSTNAME%%.*}" ] ; then
+		CFG_FQDN=`cat /etc/hostname`
+		if [ "$CFG_FQDN" != "$CUR_FQDN"  -a  "${CFG_FQDN%%.*}" != "${CUR_FQDN%%.*}" ] ; then
 			rm /etc/hostname
 		fi
 	fi

--- a/templates/nodegroup.template
+++ b/templates/nodegroup.template
@@ -807,7 +807,7 @@
                                 "##   NOTE: ami_launch_index is correct only within a single subnet)\n",
                                 "instance_id=$(curl -f http://instance-data/latest/meta-data/instance-id)\n",
                                 "ami_launch_index=$(curl -f http://instance-data/latest/meta-data/ami-launch-index)\n",
-                                "launch_node=$(grep -w `hostname` /tmp/",
+                                "launch_node=$(grep -w `hostname -s` /tmp/",
                                 {
                                     "Ref": "NodeDesignation"
                                 },


### PR DESCRIPTION
The files /tmp/brokers, /tmp/hosts use shortnames instead of FQDN. We standardize the queries for $THIS_HOST using `hostname -s`, this keeps all names consistent for all distros, thereby resolving issues with CentOS images not starting brokers.

Some case sensitive compares are also changed to ensure private IPs are properly detected.