### PR TITLE
FIX: Limits for standard storage devices are too high.

### DIFF
--- a/templates/confluent-kafka-master.template
+++ b/templates/confluent-kafka-master.template
@@ -93,7 +93,7 @@
                     "default": "Availability Zones"
                 },
                 "BootDiskSize": {
-                    "default": "Boot Disk Capacity (GB)"
+                    "default": "Boot Disk Capacity (GiB)"
                 },
                 "BrokerNodeInstanceType": {
                     "default": "Instance Type"
@@ -198,7 +198,7 @@
             "Type": "List<AWS::EC2::AvailabilityZone::Name>"
         },
         "BootDiskSize": {
-            "ConstraintDescription": "Deployment supports 8 to 128 GB for boot volumes",
+            "ConstraintDescription": "Deployment supports 8 to 128 GiB for boot volumes",
             "Default": "24",
             "Description": "Allocated EBS storage for boot disk",
             "MaxValue": "128",
@@ -236,9 +236,9 @@
             "Type": "String"
         },
         "BrokerNodeStorage": {
-            "ConstraintDescription": "No more than 4000 GB per device (16 TB per node). Be careful about exceeding your AWS Storage Limit.",
+            "ConstraintDescription": "No more than 4000 GiB per device (16 TB per node). Be careful about exceeding your AWS Storage Limit.",
             "Default": "512",
-            "Description": "Allocated EBS storage for each block device (in GB; 4 devs per node); 0 indicates ephemeral storage only",
+            "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
             "MaxValue": "4000",
             "MinValue": "0",
             "Type": "Number"
@@ -251,7 +251,7 @@
                 "st1"
             ],
             "Default": "st1",
-            "Description": "EBS volume type (blank indicates default type for ami/region).  sc1 and st1 volumes must be at least 500 GB in size.",
+            "Description": "EBS volume type (blank indicates default type for ami/region).  sc1 and st1 volumes must be at least 500 GiB in size.",
             "Type": "String"
         },
         "ClusterName": {
@@ -417,9 +417,9 @@
             "Type": "String"
         },
         "WorkerNodeStorage": {
-            "ConstraintDescription": "No more than 1000 GB per device (4 TB per node).",
+            "ConstraintDescription": "No more than 1000 GiB per device (4 TB per node).",
             "Default": "0",
-            "Description": "Allocated EBS storage for each block device (in GB; 4 devs per node); 0 indicates ephemeral storage only",
+            "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
             "MaxValue": "1000",
             "MinValue": "0",
             "Type": "Number"
@@ -446,9 +446,9 @@
             "Type": "String"
         },
         "ZookeeperNodeStorage": {
-            "ConstraintDescription": "No more than 1000 GB per device (4 TB per node).",
+            "ConstraintDescription": "No more than 1000 GiB per device (4 TB per node).",
             "Default": "0",
-            "Description": "Allocated EBS storage for each block device (in GB; 4 devs per node); 0 indicates ephemeral storage only",
+            "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
             "MaxValue": "1000",
             "MinValue": "0",
             "Type": "Number"

--- a/templates/confluent-kafka-master.template
+++ b/templates/confluent-kafka-master.template
@@ -236,7 +236,7 @@
             "Type": "String"
         },
         "BrokerNodeStorage": {
-            "ConstraintDescription": "No more than 4096 GiB per device (16 TiB per node). Be Care about exceeding your AWS Storage Limit.",
+            "ConstraintDescription": "No more than 4096 GiB per device (16 TiB per node). Be careful about exceeding your AWS Storage Limit.",
             "Default": "512",
             "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
             "MaxValue": "4096",

--- a/templates/confluent-kafka-master.template
+++ b/templates/confluent-kafka-master.template
@@ -93,7 +93,7 @@
                     "default": "Availability Zones"
                 },
                 "BootDiskSize": {
-                    "default": "Boot Disk Capacity (GiB)"
+                    "default": "Boot Disk Capacity (GB)"
                 },
                 "BrokerNodeInstanceType": {
                     "default": "Instance Type"
@@ -236,10 +236,10 @@
             "Type": "String"
         },
         "BrokerNodeStorage": {
-            "ConstraintDescription": "No more than 4096 GiB per device (16 TiB per node). Be careful about exceeding your AWS Storage Limit.",
+            "ConstraintDescription": "No more than 4096 GB per device (16 TB per node). Be careful about exceeding your AWS Storage Limit.",
             "Default": "512",
-            "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
-            "MaxValue": "4096",
+            "Description": "Allocated EBS storage for each block device (in GB; 4 devs per node); 0 indicates ephemeral storage only",
+            "MaxValue": "4000",
             "MinValue": "0",
             "Type": "Number"
         },
@@ -417,9 +417,9 @@
             "Type": "String"
         },
         "WorkerNodeStorage": {
-            "ConstraintDescription": "No more than 1000 GiB per device (4 TiB per node).",
+            "ConstraintDescription": "No more than 1000 GB per device (4 TB per node).",
             "Default": "0",
-            "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
+            "Description": "Allocated EBS storage for each block device (in GB; 4 devs per node); 0 indicates ephemeral storage only",
             "MaxValue": "1000",
             "MinValue": "0",
             "Type": "Number"
@@ -446,9 +446,9 @@
             "Type": "String"
         },
         "ZookeeperNodeStorage": {
-            "ConstraintDescription": "No more than 1000 GiB per device (4 TiB per node).",
+            "ConstraintDescription": "No more than 1000 GB per device (4 TB per node).",
             "Default": "0",
-            "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
+            "Description": "Allocated EBS storage for each block device (in GB; 4 devs per node); 0 indicates ephemeral storage only",
             "MaxValue": "1000",
             "MinValue": "0",
             "Type": "Number"

--- a/templates/confluent-kafka-master.template
+++ b/templates/confluent-kafka-master.template
@@ -236,7 +236,7 @@
             "Type": "String"
         },
         "BrokerNodeStorage": {
-            "ConstraintDescription": "No more than 4096 GiB per device (4 TiB per node).",
+            "ConstraintDescription": "No more than 4096 GiB per device (16 TiB per node). Be Care about exceeding your AWS Storage Limit.",
             "Default": "512",
             "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
             "MaxValue": "4096",
@@ -417,10 +417,10 @@
             "Type": "String"
         },
         "WorkerNodeStorage": {
-            "ConstraintDescription": "No more than 4096 GiB per device (4 TiB per node).",
+            "ConstraintDescription": "No more than 1000 GiB per device (4 TiB per node).",
             "Default": "0",
             "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
-            "MaxValue": "4096",
+            "MaxValue": "1000",
             "MinValue": "0",
             "Type": "Number"
         },
@@ -446,10 +446,10 @@
             "Type": "String"
         },
         "ZookeeperNodeStorage": {
-            "ConstraintDescription": "No more than 4096 GiB per device (4 TiB per node).",
+            "ConstraintDescription": "No more than 1000 GiB per device (4 TiB per node).",
             "Default": "0",
             "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
-            "MaxValue": "4096",
+            "MaxValue": "1000",
             "MinValue": "0",
             "Type": "Number"
         }

--- a/templates/confluent-kafka-master.template
+++ b/templates/confluent-kafka-master.template
@@ -236,7 +236,7 @@
             "Type": "String"
         },
         "BrokerNodeStorage": {
-            "ConstraintDescription": "No more than 4096 GB per device (16 TB per node). Be careful about exceeding your AWS Storage Limit.",
+            "ConstraintDescription": "No more than 4000 GB per device (16 TB per node). Be careful about exceeding your AWS Storage Limit.",
             "Default": "512",
             "Description": "Allocated EBS storage for each block device (in GB; 4 devs per node); 0 indicates ephemeral storage only",
             "MaxValue": "4000",

--- a/templates/confluent-kafka.template
+++ b/templates/confluent-kafka.template
@@ -216,7 +216,7 @@
             "Type": "String"
         },
         "BrokerNodeStorage": {
-            "ConstraintDescription": "No more than 4096 GB per device (16 TB per node). Be Careful About Exceeding your AWS Storage Limit.",
+            "ConstraintDescription": "No more than 4000 GB per device (16 TB per node). Be Careful About Exceeding your AWS Storage Limit.",
             "Default": "512",
             "Description": "Allocated EBS storage for each block device (in GB; 4 devs per node); 0 indicates ephemeral storage only",
             "MaxValue": "4000",

--- a/templates/confluent-kafka.template
+++ b/templates/confluent-kafka.template
@@ -86,7 +86,7 @@
                     "default": "Allocate a public IP for each instance"
                 },
                 "BootDiskSize": {
-                    "default": "Boot Disk Capacity (GiB)"
+                    "default": "Boot Disk Capacity (GB)"
                 },
                 "BrokerNodeInstanceType": {
                     "default": "Instance Type"
@@ -216,10 +216,10 @@
             "Type": "String"
         },
         "BrokerNodeStorage": {
-            "ConstraintDescription": "No more than 4096 GiB per device (16 TiB per node). Be Careful About Exceeding your AWS Storage Limit.",
+            "ConstraintDescription": "No more than 4096 GB per device (16 TB per node). Be Careful About Exceeding your AWS Storage Limit.",
             "Default": "512",
-            "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
-            "MaxValue": "4096",
+            "Description": "Allocated EBS storage for each block device (in GB; 4 devs per node); 0 indicates ephemeral storage only",
+            "MaxValue": "4000",
             "MinValue": "0",
             "Type": "Number"
         },
@@ -370,9 +370,9 @@
             "Type": "String"
         },
         "WorkerNodeStorage": {
-            "ConstraintDescription": "No more than 1000 GiB per device (4 TiB per node).",
+            "ConstraintDescription": "No more than 1000 GB per device (4 TB per node).",
             "Default": "0",
-            "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
+            "Description": "Allocated EBS storage for each block device (in GB; 4 devs per node); 0 indicates ephemeral storage only",
             "MaxValue": "1000",
             "MinValue": "0",
             "Type": "Number"
@@ -399,9 +399,9 @@
             "Type": "String"
         },
         "ZookeeperNodeStorage": {
-            "ConstraintDescription": "No more than 1000 GiB per device (4 TiB per node).",
+            "ConstraintDescription": "No more than 1000 GB per device (4 TB per node).",
             "Default": "0",
-            "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
+            "Description": "Allocated EBS storage for each block device (in GB; 4 devs per node); 0 indicates ephemeral storage only",
             "MaxValue": "1000",
             "MinValue": "0",
             "Type": "Number"

--- a/templates/confluent-kafka.template
+++ b/templates/confluent-kafka.template
@@ -86,7 +86,7 @@
                     "default": "Allocate a public IP for each instance"
                 },
                 "BootDiskSize": {
-                    "default": "Boot Disk Capacity (GB)"
+                    "default": "Boot Disk Capacity (GiB)"
                 },
                 "BrokerNodeInstanceType": {
                     "default": "Instance Type"
@@ -178,7 +178,7 @@
             "Type": "String"
         },
         "BootDiskSize": {
-            "ConstraintDescription": "Deployment supports 8 to 128 GB for boot volumes",
+            "ConstraintDescription": "Deployment supports 8 to 128 GiB for boot volumes",
             "Default": "24",
             "Description": "Allocated EBS storage for boot disk",
             "MaxValue": "128",
@@ -216,9 +216,9 @@
             "Type": "String"
         },
         "BrokerNodeStorage": {
-            "ConstraintDescription": "No more than 4000 GB per device (16 TB per node). Be Careful About Exceeding your AWS Storage Limit.",
+            "ConstraintDescription": "No more than 4000 GiB per device (16 TB per node). Be Careful About Exceeding your AWS Storage Limit.",
             "Default": "512",
-            "Description": "Allocated EBS storage for each block device (in GB; 4 devs per node); 0 indicates ephemeral storage only",
+            "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
             "MaxValue": "4000",
             "MinValue": "0",
             "Type": "Number"
@@ -231,7 +231,7 @@
                 "st1"
             ],
             "Default": "st1",
-            "Description": "EBS volume type (blank indicates default type for ami/region).  sc1 and st1 volumes must be at least 500 GB in size.",
+            "Description": "EBS volume type (blank indicates default type for ami/region).  sc1 and st1 volumes must be at least 500 GiB in size.",
             "Type": "String"
         },
         "ClusterName": {
@@ -370,9 +370,9 @@
             "Type": "String"
         },
         "WorkerNodeStorage": {
-            "ConstraintDescription": "No more than 1000 GB per device (4 TB per node).",
+            "ConstraintDescription": "No more than 1000 GiB per device (4 TB per node).",
             "Default": "0",
-            "Description": "Allocated EBS storage for each block device (in GB; 4 devs per node); 0 indicates ephemeral storage only",
+            "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
             "MaxValue": "1000",
             "MinValue": "0",
             "Type": "Number"
@@ -399,9 +399,9 @@
             "Type": "String"
         },
         "ZookeeperNodeStorage": {
-            "ConstraintDescription": "No more than 1000 GB per device (4 TB per node).",
+            "ConstraintDescription": "No more than 1000 GiB per device (4 TB per node).",
             "Default": "0",
-            "Description": "Allocated EBS storage for each block device (in GB; 4 devs per node); 0 indicates ephemeral storage only",
+            "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
             "MaxValue": "1000",
             "MinValue": "0",
             "Type": "Number"

--- a/templates/confluent-kafka.template
+++ b/templates/confluent-kafka.template
@@ -216,7 +216,7 @@
             "Type": "String"
         },
         "BrokerNodeStorage": {
-            "ConstraintDescription": "No more than 4096 GiB per device (16 TiB per node).",
+            "ConstraintDescription": "No more than 4096 GiB per device (16 TiB per node). Be Careful About Exceeding your AWS Storage Limit.",
             "Default": "512",
             "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
             "MaxValue": "4096",
@@ -370,10 +370,10 @@
             "Type": "String"
         },
         "WorkerNodeStorage": {
-            "ConstraintDescription": "No more than 4096 GiB per device (16 TiB per node).",
+            "ConstraintDescription": "No more than 1000 GiB per device (4 TiB per node).",
             "Default": "0",
             "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
-            "MaxValue": "4096",
+            "MaxValue": "1000",
             "MinValue": "0",
             "Type": "Number"
         },
@@ -399,10 +399,10 @@
             "Type": "String"
         },
         "ZookeeperNodeStorage": {
-            "ConstraintDescription": "No more than 4096 GiB per device (16 TiB per node).",
+            "ConstraintDescription": "No more than 1000 GiB per device (4 TiB per node).",
             "Default": "0",
             "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
-            "MaxValue": "4096",
+            "MaxValue": "1000",
             "MinValue": "0",
             "Type": "Number"
         }

--- a/templates/nodegroup.template
+++ b/templates/nodegroup.template
@@ -138,10 +138,10 @@
             "Type": "String"
         },
         "PersistentStorage": {
-            "ConstraintDescription": "No more than 4096 GB per device (16 TB per node).",
+            "ConstraintDescription": "No more than 4000 GB per device (16 TB per node).",
             "Default": "0",
             "Description": "Allocated EBS storage for each block device (in GB; 4 devs per node); 0 indicates ephemeral storage only",
-            "MaxValue": "4096",
+            "MaxValue": "4000",
             "MinValue": "0",
             "Type": "Number"
         },

--- a/templates/nodegroup.template
+++ b/templates/nodegroup.template
@@ -138,9 +138,9 @@
             "Type": "String"
         },
         "PersistentStorage": {
-            "ConstraintDescription": "No more than 4000 GB per device (16 TB per node).",
+            "ConstraintDescription": "No more than 4000 GiB per device (16 TB per node).",
             "Default": "0",
-            "Description": "Allocated EBS storage for each block device (in GB; 4 devs per node); 0 indicates ephemeral storage only",
+            "Description": "Allocated EBS storage for each block device (in GiB; 4 devs per node); 0 indicates ephemeral storage only",
             "MaxValue": "4000",
             "MinValue": "0",
             "Type": "Number"
@@ -153,7 +153,7 @@
                 "st1"
             ],
             "Default": "",
-            "Description": "EBS volume type (blank indicates default type for ami/region).  sc1 and st1 volumes must be at least 500 GB in size.",
+            "Description": "EBS volume type (blank indicates default type for ami/region).  sc1 and st1 volumes must be at least 500 GiB in size.",
             "Type": "String"
         },
         "QSS3BucketName": {


### PR DESCRIPTION
Zookeeper and Worker instances use standard volumes. These volumes only support max of 1GB per block device. Templates now correctly limit input to under 1GB.